### PR TITLE
PHP8 fix

### DIFF
--- a/lib/MailSo/Sieve/ManageSieveClient.php
+++ b/lib/MailSo/Sieve/ManageSieveClient.php
@@ -301,7 +301,7 @@ class ManageSieveClient extends \MailSo\Net\NetClient
 		$sScript = '';
 		if (is_array($mResponse) && 0 < count($mResponse))
 		{
-			if ('{' === $mResponse[0]{0})
+			if ('{' === $mResponse[0][0])
 			{
 				array_shift($mResponse);
 			}


### PR DESCRIPTION
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in ./vendor/afterlogic/mailso/lib/MailSo/Sieve/ManageSieveClient.php on line 304