### PR TITLE
A better patch for the problem described at https://s.afterlogic.com/…

### DIFF
--- a/lib/MailSo/Base/StreamWrappers/SubStreams.php
+++ b/lib/MailSo/Base/StreamWrappers/SubStreams.php
@@ -138,7 +138,7 @@ class SubStreams
 	{
 		$sReturn = '';
 		$mCurrentPart = null;
-
+		
 		if ($iCount > 0)
 		{
 			if ($iCount < \strlen($this->sBuffer))
@@ -170,20 +170,8 @@ class SubStreams
 							{
 								return false;
 							}
-
+							
 							$sReturn .= $sReadResult;
-
-							$iLen = \strlen($sReturn);
-							if ($iCount < $iLen)
-							{
-								$this->sBuffer = \substr($sReturn, $iCount);
-								$sReturn = \substr($sReturn, 0, $iCount);
-								$iCount = 0;
-							}
-							else
-							{
-								$iCount -= $iLen;
-							}
 						}
 						else
 						{
@@ -192,21 +180,20 @@ class SubStreams
 					}
 					else if (\is_string($mCurrentPart))
 					{
-						if (\strlen($mCurrentPart) > $iCount)
-						{
-							/** $mCurrentPart will not fit in the remaining
-							 * $iCount bytes of $sReturn. Break out of the
-							 * loop without copying it: we will be called
-							 * again with a larger $iCount that it should
-							 * fit into.
-							 */
-							break;
-						}
-						else
-						{
-							$sReturn .= $mCurrentPart;
-							$this->iIndex++;
-						}
+						$sReturn .= $mCurrentPart;
+						$this->iIndex++;
+					}
+					
+					$iLen = \strlen($sReturn);
+					if ($iCount < $iLen)
+					{
+						$this->sBuffer = \substr($sReturn, $iCount);
+						$sReturn = \substr($sReturn, 0, $iCount);
+						$iCount = 0;
+					}
+					else
+					{
+						$iCount -= $iLen;
 					}
 				}
 			}


### PR DESCRIPTION
…forum/forum_posts.asp?TID=7995&PN=1&TPN=1

This updated patch addresses the same problem, but does so more elegantly by moving the existing code that handles buffering of data larger than $iCount so that it applies to the "if (\is_string($mCurrentPart))" case too.

This will make the code correctly handle a case where $mCurrentPart is > 8192 bytes to start with, which neither the original code nor the first version of the patch handled.