### PR TITLE
Fix problem where a read from a single Base64-encoded line that is longer than 8192 bytes is corrupted

### DIFF
--- a/lib/MailSo/Base/StreamWrappers/Binary.php
+++ b/lib/MailSo/Base/StreamWrappers/Binary.php
@@ -332,7 +332,7 @@ class Binary
 						$sReturn .= self::$sFunctionName($this->sReadEndBuffer.$sReadResult,
 							$this->sReadEndBuffer, $this->sFromEncoding, $this->sToEncoding);
 
-						$iDecodeLen = strlen($sReturn);
+						$iDecodeLen = strlen($sReadResult);
 						if ($iCount < $iDecodeLen)
 						{
 							$this->sBuffer = substr($sReturn, $iCount);


### PR DESCRIPTION
Fix problem where a read from a single Base64-encoded line that is longer than 8192 bytes is corrupted.

The problem happens because stream_read() calls InlineBase64Decode(), so the code effectively does this:

$sReadResult = fread($this->rStream, 8192);
$sReturn .= InlineBase64Decode($this->sReadEndBuffer.$sReadResult,
	$this->sReadEndBuffer, $this->sFromEncoding, $this->sToEncoding);
$iDecodeLen = strlen($sReturn);

At this point, $iDecodeLen should be set to 8192 because it successfully read 8192 bytes from the original stream. However, it's wrongly set to 6144 bytes, because $sReturn is only 3/4 of the original size after InlineBase64Decode. That causes the "if ($iCount < $iDecodeLen)" loop to wrongly run again to consume another 2048 bytes.

The correct thing to do is set $iDecodeLen to length of what we read from the original stream (8192 bytes).

This bug is probably rarely seen because SMTP prohibits lines this long; however, they are actually seen in the wild sometimes (I found this bug while tracking down a corrupted PDF attachment sent in a single 136KB Base64-encoded line).